### PR TITLE
Better detection of discount code use in pmpro_checkout_level filter

### DIFF
--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -210,7 +210,7 @@ function pmproarc_checkout_level($level) {
 		return $level;
 
 	//not if using a discount code
-	if(!empty($discount_code))
+	if ( ! empty( $discount_code ) || ! empty( $_REQUEST['discount_code'] ) )
 		return $level;
 
 	if(isset($_REQUEST['autorenew_present']) && empty($_REQUEST['autorenew']))


### PR DESCRIPTION
Now also checking `$_REQUEST` for discount code use in addition to `global $discount_code`, which in specific cases missed that a discount code was applied.

Customer bug report (mods only): https://www.paidmembershipspro.com/forums/topic/coupon-link-without-automatic-renewal-paypal-issue/?skipped