### PR TITLE
Marking the plugin as MMPU-incompatible

### DIFF
--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -29,6 +29,15 @@ function pmproarc_load_textdomain() {
 }
 add_action( 'init', 'pmproarc_load_textdomain' );
 
+/**
+  * Mark the plugin as MMPU-incompatible.
+  */
+ function pmproarc_mmpu_incompatible_add_ons( $incompatible ) {
+     $incompatible[] = 'PMPro Auto-Renewal Checkbox Add On';
+     return $incompatible;
+ }
+ add_filter( 'pmpro_mmpu_incompatible_add_ons', 'pmproarc_mmpu_incompatible_add_ons' );
+
 
 /*
 	Add settings to the edit levels page


### PR DESCRIPTION
Marking the plugin as MMPU-incompatible for PMPro v3.0 update.