### PR TITLE
Update headings hierarchy for a11y

### DIFF
--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -39,7 +39,7 @@ function pmproarc_pmpro_membership_level_after_other_settings() {
 	$options = pmproarc_getOptions($level_id);
 ?>
 <div id="arc_setting_div">
-	<h2 class="topborder"><?php esc_html_e('Auto-Renewal Settings', 'pmpro-auto-renewal-checkbox');?></h2>
+	<h3 class="topborder"><?php esc_html_e('Auto-Renewal Settings', 'pmpro-auto-renewal-checkbox');?></h3>
 	<p><?php esc_html_e('Change this setting to make-auto renewals optional at checkout.', 'pmpro-auto-renewal-checkbox');?></p>
 	<table>
 	<tbody class="form-table">

--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -39,7 +39,7 @@ function pmproarc_pmpro_membership_level_after_other_settings() {
 	$options = pmproarc_getOptions($level_id);
 ?>
 <div id="arc_setting_div">
-	<h3 class="topborder"><?php esc_html_e('Auto-Renewal Settings', 'pmpro-auto-renewal-checkbox');?></h3>
+	<h2 class="topborder"><?php esc_html_e('Auto-Renewal Settings', 'pmpro-auto-renewal-checkbox');?></h2>
 	<p><?php esc_html_e('Change this setting to make-auto renewals optional at checkout.', 'pmpro-auto-renewal-checkbox');?></p>
 	<table>
 	<tbody class="form-table">
@@ -149,9 +149,9 @@ function pmproarc_pmpro_checkout_boxes() {
 	?>
 	<div id="pmpro_autorenewal_checkbox" class="pmpro_checkout">
 		<hr />
-		<h3>
-			<span class="pmpro_checkout-h3-name"><?php esc_html_e('Would you like to set up automatic renewals?', 'pmpro-auto-renewal-checkbox');?></span>
-		</h3>
+		<h2>
+			<span class="pmpro_checkout-h2-name"><?php esc_html_e('Would you like to set up automatic renewals?', 'pmpro-auto-renewal-checkbox');?></span>
+		</h2>
 		<div class="pmpro_checkout-fields">
 			<div class="pmpro_checkout-field-checkbox pmpro_checkout_field-autorenew">
 				<input type="checkbox" id="autorenew" name="autorenew" value="1" <?php checked($autorenew, 1);?> />


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.