### PR TITLE
Added compatibility for prefixed request var

### DIFF
--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -233,8 +233,9 @@ function pmproarc_checkout_level($level) {
 		return $level;
 
 	//not if using a discount code
-	if ( ! empty( $discount_code ) || ! empty( $_REQUEST['discount_code'] ) )
+	if ( ! empty( $discount_code ) || ! empty( $_REQUEST['discount_code'] ) || ! empty( $_REQUEST['pmpro_discount_code'] ) ) {
 		return $level;
+	}
 
 	if(isset($_REQUEST['autorenew_present']) && empty($_REQUEST['autorenew']))
 		$autorenew = 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In PMPro v3.0, we prefixed some request variable index names used at checkout. One of those names that we prefixed was `discount_code`.

In the PMPro Auto Renewal Checkbox Add On, the plugin was designed to ignore the checkbox setting whenever a discount code is used to avoid issues at checkout, but this code was never updated to use the prefixed request variable name. As a result, checkouts sometimes broke when discount codes were used alongside PMPro ARC.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
