### PR TITLE
Now setting profile start date on checkout level for 3.4 compat

### DIFF
--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -310,7 +310,6 @@ function pmproarc_profile_start_date_delay_subscription($startdate, $order) {
     
 	return $startdate;
 }
-add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subscription', 9, 2 );
 
 /**
  * Hook the legacy pmproarc_profile_start_date_delay_subscription() function if running a PMPro version before v3.4.
@@ -320,7 +319,7 @@ add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subsc
  */
 function pmprosd_hook_pmpro_profile_start_date() {
 	if ( version_compare( PMPRO_VERSION, '3.4', '<' ) ) {
-		add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subscription', 10, 2 );
+		add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subscription', 9, 2 );
 	}
 }
 add_action( 'init', 'pmprosd_hook_pmpro_profile_start_date' );

--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -312,13 +312,43 @@ function pmproarc_profile_start_date_delay_subscription($startdate, $order) {
 }
 add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subscription', 9, 2 );
 
+/**
+ * Hook the legacy pmproarc_profile_start_date_delay_subscription() function if running a PMPro version before v3.4.
+ * Otherwise, pmproarc_checkout_level_extend_memberships() will be used to extend memberships when purchasing recurring levels.
+ *
+ * @since TBD
+ */
+function pmprosd_hook_pmpro_profile_start_date() {
+	if ( version_compare( PMPRO_VERSION, '3.4', '<' ) ) {
+		add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subscription', 10, 2 );
+	}
+}
+add_action( 'init', 'pmprosd_hook_pmpro_profile_start_date' );
+
 /*
-	If checking out without recurring with an active recurring subscription for the same level,
-	extend from the next payment date instead of the date of checkout.
-*/
+ * If checking out for a level that the user already has, extend the membership from their next payment date or expiration date.
+ *
+ * @since TBD Updated to extend memberships when purchasing recurring levels as well.
+ *
+ * @param object $level The level object.
+ */
 function pmproarc_checkout_level_extend_memberships( $level ) {
-	//does this level expire? are they an existing user of this level?
-	if ( ! empty( $level ) && ! empty( $level->expiration_number ) && pmpro_hasMembershipLevel( $level->id ) ) {
+	// If we don't have a level for some reason, bail.
+	if ( empty( $level ) ) {
+		return $level;
+	}
+
+	// If the user does not already have this level, bail.
+	$user_level = pmpro_getSpecificMembershipLevelForUser( get_current_user_id(), $level->id );
+	if ( empty( $user_level ) ) {
+		return $level;
+	}
+
+	// Check whether an expiring or recurring level is being purchased.
+	if ( ! empty( $level->expiration_number ) ) {
+		// The level being purchased has an expiration date.
+		// Core PMPro will extend the expiration date if the user already has a level with an expiration date (see pmpro_checkout_level_extend_memberships()).
+		// So here, we only need to extend the expiration date if the user has a subscription for this level.
 		if ( class_exists( 'PMPro_Subscription' ) ) {
 			// Check if the user has a subscription for this level.
 			$subscriptions = PMPro_Subscription::get_subscriptions_for_user( get_current_user_id(), $level->id );
@@ -369,6 +399,21 @@ function pmproarc_checkout_level_extend_memberships( $level ) {
 			$level->expiration_number = $total_days;
 			$level->expiration_period = "Day";
 		}
+	} elseif ( pmpro_isLevelRecurring( $level ) ) {
+		// The level being purchased is recurring.
+		// If the user already has a recurring level, they shouldn't need to check out again.
+		// So here, we only want to extend the profile start date if the user currently has an expiring level.
+		if ( empty( $user_level->enddate ) ) {
+			return $level;
+		}
+
+		// If a profile start date is already set (possibly by Subscription Delays or prorations), respect that.
+		if ( ! empty( $level->profile_start_date ) ) {
+			return $level;
+		}
+
+		// Add the billing cycle and number of periods to the user's current expiration date.
+		$level->profile_start_date = date( 'Y-m-d H:i:s', strtotime( '+' . $level->cycle_number . ' ' . $level->cycle_period, $user_level->enddate ) );
 	}
 
 	return $level;

--- a/pmpro-auto-renewal-checkbox.php
+++ b/pmpro-auto-renewal-checkbox.php
@@ -318,7 +318,7 @@ function pmproarc_profile_start_date_delay_subscription($startdate, $order) {
  * @since TBD
  */
 function pmprosd_hook_pmpro_profile_start_date() {
-	if ( version_compare( PMPRO_VERSION, '3.4', '<' ) ) {
+	if ( defined( 'PMPRO_VERSION' ) && version_compare( PMPRO_VERSION, '3.4', '<' ) ) {
 		add_filter( 'pmpro_profile_start_date', 'pmproarc_profile_start_date_delay_subscription', 9, 2 );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
PMPro v3.4 is deprecating the `pmpro_profile_start_date` filter in favor of setting the profile start date directly on the checkout level. This PR makes PMPro Auto-Renewal Checkbox compatible with this new approach.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
